### PR TITLE
chore(release): align versioning and harden public repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     name: Quality Gate
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
 
     steps:
       - name: Checkout repository
@@ -51,7 +51,6 @@ jobs:
         run: pytest --cov=src/omnifocus --cov-report=json:coverage.json --cov-fail-under=100 -q
 
       - name: Generate coverage badge payload
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           python - <<'PY'
           import json
@@ -84,8 +83,31 @@ jobs:
           )
           PY
 
+      - name: Upload coverage badge artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: coverage-badge
+          path: coverage-badge.json
+
+  publish-badge:
+    name: Publish Coverage Badge
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Download coverage badge artifact
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          name: coverage-badge
+          path: badge
+
       - name: Publish coverage badge branch
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -107,7 +129,7 @@ jobs:
             cd "$GITHUB_WORKSPACE"
           fi
 
-          cp coverage-badge.json "$tmpdir/coverage-badge.json"
+          cp badge/coverage-badge.json "$tmpdir/coverage-badge.json"
           touch "$tmpdir/.nojekyll"
 
           cd "$tmpdir"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.0.3] - 2026-03-24
+
+### Changed
+
+- Split CI badge publishing into a separate write-scoped job while keeping the public badge URL stable
+- Normalized release metadata so package version, changelog, tags, and release assets are aligned again
+- Refreshed the local agent operating rules for the now-public repository and hardened release process
+
+### Fixed
+
+- Main branch protection readiness for required checks and signed-commit enforcement
+- Public-repo release hygiene around version drift between `pyproject.toml`, changelog entries, and release tags
+
+## [1.0.2] - 2026-03-24
+
+### Changed
+
+- Pinned GitHub Actions workflow dependencies to full commit SHAs for public-repo policy compliance
+- Improved README release badging and container release presentation
+
+### Fixed
+
+- Release workflow deprecation warnings by removing the remaining Node 20-based actions
+- Coverage badge branch publishing by configuring Git identity in the temporary checkout
+- Coverage badge workflow YAML errors discovered during release hardening
+
 ## [1.0.1] - 2026-03-24
 
 ### Added
@@ -27,9 +53,6 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - GitHub Actions readiness for the Node 24 transition
 - CI regressions around formatting and CLI launcher coverage discovered during release hardening
-- release workflow deprecation warnings by removing remaining Node 20-based release actions
-- badge branch publishing on first run by configuring Git identity in the temporary checkout
-- invalid YAML in the coverage badge workflow script block
 
 ## [1.0.0] - 2026-03-23
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnifocus-cli"
-version = "1.0.0"
+version = "1.0.3"
 description = "Independent CLI and MCP server for OmniFocus 4, running in Podman"
 readme = "README.md"
 requires-python = ">=3.14"


### PR DESCRIPTION
## Summary
- align package metadata and changelog for the v1.0.3 release
- split coverage badge publishing into a separate write-scoped CI job
- keep workflow actions pinned to full SHAs and preserve the public badge URL

## GitHub settings already applied
- enabled branch protection on main
- enabled required signed commits on main
- enabled secret scanning and push protection on the public repo

## Notes
- secret_scanning_non_provider_patterns and secret_scanning_validity_checks remained disabled after the API update and may require manual UI enablement if you want them too
- local-only AGENTS.md was updated in this clone but intentionally not committed