### PR TITLE
fix(version): derive cli version from package metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.0.4] - 2026-03-24
+
+### Fixed
+
+- CLI and container `--version` output now reads the installed package metadata instead of a stale hardcoded module constant
+- Release `v1.0.4` restores consistency between Git tag, package metadata, release assets, and runtime version reporting
+
 ## [1.0.3] - 2026-03-24
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnifocus-cli"
-version = "1.0.3"
+version = "1.0.4"
 description = "Independent CLI and MCP server for OmniFocus 4, running in Podman"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/omnifocus/__init__.py
+++ b/src/omnifocus/__init__.py
@@ -6,6 +6,11 @@ and exposes task management via a Click CLI and an MCP server for Claude.
 
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError, version
+
 __author__ = "Maciej Szymczak <maciej@szymczak.at>"
 
-__version__ = "1.0.0"
+try:
+    __version__ = version("omnifocus-cli")
+except PackageNotFoundError:
+    __version__ = "0+unknown"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
+from omnifocus import __version__
 from omnifocus.cli import _parse_due, cli
 from omnifocus.errors import OFEncryptionError, OFError, OFWebDAVError
 from omnifocus.models import Folder, OFModel, Project, Task
@@ -836,7 +837,7 @@ class TestHelp:
         runner = CliRunner()
         result = runner.invoke(cli, ["--version"])
         assert result.exit_code == 0
-        assert "of, version 1.0.0" in result.output
+        assert f"of, version {__version__}" in result.output
 
     def test_tasks_help(self) -> None:
         runner = CliRunner()

--- a/tests/test_package_init.py
+++ b/tests/test_package_init.py
@@ -1,0 +1,38 @@
+"""Tests for :mod:`omnifocus.__init__`."""
+
+from __future__ import annotations
+
+import importlib.util
+from importlib.metadata import PackageNotFoundError
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "src" / "omnifocus" / "__init__.py"
+
+
+def _load_init_module() -> ModuleType:
+    """Load ``omnifocus.__init__`` under a temporary module name."""
+    spec = importlib.util.spec_from_file_location("test_omnifocus_init", MODULE_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_version_reads_package_metadata() -> None:
+    """Package version should come from installed package metadata."""
+    with patch("importlib.metadata.version", return_value="1.0.4"):
+        module = _load_init_module()
+
+    assert module.__version__ == "1.0.4"
+
+
+def test_version_falls_back_when_metadata_missing() -> None:
+    """Missing package metadata should use the local fallback version."""
+    with patch("importlib.metadata.version", side_effect=PackageNotFoundError):
+        module = _load_init_module()
+
+    assert module.__version__ == "0+unknown"


### PR DESCRIPTION
## Summary
- derive CLI runtime version from installed package metadata instead of a stale hardcoded constant
- bump package metadata and changelog to 1.0.4
- add coverage for both metadata and fallback version paths

## Why
The v1.0.3 release assets were correct, but the published container still reported `of, version 1.0.0`. This fixes the runtime version source so future releases stay aligned.