### PR TITLE
fix(mcp): preserve task ids after add_task writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.0.5] - 2026-03-24
+
+### Fixed
+
+- Preserve freshly created tasks in the parsed model when later OmniFocus `op="update"`
+  deltas omit `<name>`, so MCP `get_task` and `update_task` can immediately resolve IDs
+  returned by `add_task`
+- Merge partial task updates in the parser instead of treating name-less update deltas as
+  deletion markers
+
 ## [1.0.4] - 2026-03-24
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnifocus-cli"
-version = "1.0.4"
+version = "1.0.5"
 description = "Independent CLI and MCP server for OmniFocus 4, running in Podman"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/omnifocus/parser.py
+++ b/src/omnifocus/parser.py
@@ -35,6 +35,7 @@ __author__ = "Maciej Szymczak <maciej@szymczak.at>"
 import io
 import xml.etree.ElementTree as ET
 import zipfile
+from copy import deepcopy
 from datetime import UTC, datetime
 
 from omnifocus.errors import OFParseError
@@ -162,6 +163,27 @@ def _idref(el: ET.Element, local: str) -> str | None:
 _RawIndex = dict[str, dict[str, ET.Element]]
 
 
+def _merge_update_element(existing: ET.Element, update: ET.Element) -> ET.Element:
+    """Merge an ``op="update"`` element into an existing indexed element.
+
+    OmniFocus update transactions often contain only the changed fields. Replacing the
+    whole indexed element would discard unchanged fields from earlier snapshots.
+    """
+    merged = deepcopy(existing)
+    for attr_name, attr_value in update.attrib.items():
+        if attr_name != "op":
+            merged.set(attr_name, attr_value)
+
+    replacement_tags = {child.tag for child in update}
+    if replacement_tags:
+        for child in list(merged):
+            if child.tag in replacement_tags:
+                merged.remove(child)
+        for child in update:
+            merged.append(deepcopy(child))
+    return merged
+
+
 def _index_elements(root: ET.Element, index: _RawIndex) -> None:
     """Index all direct children of *root* into *index* using upsert/delete semantics.
 
@@ -178,8 +200,21 @@ def _index_elements(root: ET.Element, index: _RawIndex) -> None:
             continue
         local = elem.tag.replace(_NS, "")
         bucket = index.setdefault(local, {})
+        op = elem.get("op")
 
-        # Deletion marker: element is present but has no <name> child.
+        if op == "update":
+            existing = bucket.get(eid)
+            if existing is None:
+                bucket[eid] = elem
+            else:
+                bucket[eid] = _merge_update_element(existing, elem)
+            continue
+
+        if op == "delete":
+            bucket.pop(eid, None)
+            continue
+
+        # Legacy deletion marker: element is present but has no <name> child.
         # Applies to folder, task, context elements.
         has_name = elem.find(_tag("name")) is not None
         if not has_name and local in ("task", "folder", "context"):

--- a/tests/test_package_init.py
+++ b/tests/test_package_init.py
@@ -24,10 +24,10 @@ def _load_init_module() -> ModuleType:
 
 def test_version_reads_package_metadata() -> None:
     """Package version should come from installed package metadata."""
-    with patch("importlib.metadata.version", return_value="1.0.4"):
+    with patch("importlib.metadata.version", return_value="1.0.5"):
         module = _load_init_module()
 
-    assert module.__version__ == "1.0.4"
+    assert module.__version__ == "1.0.5"
 
 
 def test_version_falls_back_when_metadata_missing() -> None:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -462,6 +462,131 @@ class TestTransactionMerge:
             "weekly-review-2",
         }
 
+    def test_update_without_name_merges_into_existing_task(self) -> None:
+        base = make_zip(_BASE_XML)
+        tx = make_zip("""\
+<?xml version="1.0" encoding="UTF-8"?>
+<omnifocus xmlns="http://www.omnigroup.com/namespace/OmniFocus/v2">
+  <task id="t1" op="update">
+    <added>2026-01-01T00:00:00.000Z</added>
+    <modified>2026-01-03T00:00:00.000Z</modified>
+    <due>2026-01-05T19:00:00.000</due>
+  </task>
+</omnifocus>
+""")
+        model = build_model(base, [tx])
+        assert model.tasks["t1"].name == "Original name"
+        assert model.tasks["t1"].due is not None
+        assert model.tasks["t1"].due.isoformat() == "2026-01-05T19:00:00"
+
+    def test_app_style_task_creation_with_extra_update_remains_visible(self) -> None:
+        base = make_zip("""\
+<?xml version="1.0" encoding="UTF-8"?>
+<omnifocus xmlns="http://www.omnigroup.com/namespace/OmniFocus/v2"/>
+""")
+        txs = [
+            make_zip("""\
+<?xml version="1.0" encoding="UTF-8"?>
+<omnifocus xmlns="http://www.omnigroup.com/namespace/OmniFocus/v2">
+  <task id="new1">
+    <project/>
+    <inbox>true</inbox>
+    <task/>
+    <added>2026-01-01T00:00:00.000Z</added>
+    <name/>
+    <note/>
+    <rank>1</rank>
+    <hidden/>
+    <context/>
+    <start/>
+    <planned/>
+    <due/>
+    <completed/>
+    <estimated-minutes/>
+    <order>sequential</order>
+    <flagged>false</flagged>
+    <completed-by-children>false</completed-by-children>
+    <repetition-rule/>
+    <repetition-method/>
+    <repetition-schedule-type/>
+    <repetition-anchor-date/>
+    <catch-up-automatically>false</catch-up-automatically>
+    <next-clone-identifier>0</next-clone-identifier>
+    <due-date-alarm-policy/>
+    <defer-date-alarm-policy/>
+    <latest-time-to-start-alarm-policy/>
+    <planned-date-alarm-policy/>
+  </task>
+</omnifocus>
+"""),
+            make_zip("""\
+<?xml version="1.0" encoding="UTF-8"?>
+<omnifocus xmlns="http://www.omnigroup.com/namespace/OmniFocus/v2">
+  <task id="new1" op="update">
+    <added>2026-01-01T00:00:00.000Z</added>
+    <modified>2026-01-02T00:00:00.000Z</modified>
+    <name>Created via updates</name>
+  </task>
+</omnifocus>
+"""),
+            make_zip("""\
+<?xml version="1.0" encoding="UTF-8"?>
+<omnifocus xmlns="http://www.omnigroup.com/namespace/OmniFocus/v2">
+  <task id="new1" op="update">
+    <added>2026-01-01T00:00:00.000Z</added>
+    <modified>2026-01-03T00:00:00.000Z</modified>
+    <due>2026-01-10T19:00:00.000</due>
+  </task>
+</omnifocus>
+"""),
+        ]
+        model = build_model(base, txs)
+        assert model.tasks["new1"].name == "Created via updates"
+        assert model.tasks["new1"].due is not None
+        assert model.tasks["new1"].due.isoformat() == "2026-01-10T19:00:00"
+
+    def test_update_without_existing_entry_is_indexed(self) -> None:
+        base = make_zip("""\
+<?xml version="1.0" encoding="UTF-8"?>
+<omnifocus xmlns="http://www.omnigroup.com/namespace/OmniFocus/v2"/>
+""")
+        tx = make_zip("""\
+<?xml version="1.0" encoding="UTF-8"?>
+<omnifocus xmlns="http://www.omnigroup.com/namespace/OmniFocus/v2">
+  <task id="orphan" op="update">
+    <added>2026-01-01T00:00:00.000Z</added>
+    <modified>2026-01-01T00:00:00.000Z</modified>
+    <name>Orphan update</name>
+  </task>
+</omnifocus>
+""")
+        model = build_model(base, [tx])
+        assert model.tasks["orphan"].name == "Orphan update"
+
+    def test_delete_op_removes_task(self) -> None:
+        base = make_zip(_BASE_XML)
+        tx = make_zip("""\
+<?xml version="1.0" encoding="UTF-8"?>
+<omnifocus xmlns="http://www.omnigroup.com/namespace/OmniFocus/v2">
+  <task id="t1" op="delete">
+    <delete-snapshot/>
+  </task>
+</omnifocus>
+""")
+        model = build_model(base, [tx])
+        assert "t1" not in model.tasks
+
+    def test_empty_update_keeps_existing_task_intact(self) -> None:
+        base = make_zip(_BASE_XML)
+        tx = make_zip("""\
+<?xml version="1.0" encoding="UTF-8"?>
+<omnifocus xmlns="http://www.omnigroup.com/namespace/OmniFocus/v2">
+  <task id="t1" op="update"/>
+</omnifocus>
+""")
+        model = build_model(base, [tx])
+        assert model.tasks["t1"].name == "Original name"
+
 
 # ---------------------------------------------------------------------------
 # Edge cases

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -675,6 +675,35 @@ class TestWritePath:
         assert "<name>Track state</name>" in second_xml
 
     @pytest.mark.asyncio
+    async def test_add_task_with_due_is_visible_after_force_refresh(self, tmp_path: Path) -> None:
+        monkeypatch = pytest.MonkeyPatch()
+        monkeypatch.setenv("OF_CHAIN_SHAPE", "linear")
+        store, client = _make_store(tmp_path)
+        due_dt = datetime(2026, 4, 10, 19, 0, 0)
+        result = await store.add_task(name="Visible after refresh", due_dt=due_dt)
+        monkeypatch.undo()
+
+        zip_uploads = [
+            call for call in client.put_file.await_args_list if call.args[0].endswith(".zip")
+        ]
+        uploaded_payloads = {call.args[0]: call.args[1] for call in zip_uploads}
+        client.list_entries.return_value = [
+            "00000000000000=base+tail.zip",
+            *uploaded_payloads.keys(),
+        ]
+
+        async def _get_uploaded_or_baseline(name: str) -> bytes:
+            if name in uploaded_payloads:
+                return uploaded_payloads[name]
+            return make_zip(_EMPTY_XML)
+
+        client.get_file = AsyncMock(side_effect=_get_uploaded_or_baseline)
+        model = await store.load(force_refresh=True)
+        task = model.tasks[result["task_id"]]
+        assert task.name == "Visible after refresh"
+        assert task.due == due_dt
+
+    @pytest.mark.asyncio
     async def test_add_task_chain_then_client_uploads_client_once(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary
- fix parser merge semantics for OmniFocus op="update" task deltas
- keep newly created tasks visible after follow-up due/start/note updates
- release the fix as version 1.0.5 with changelog and regression coverage

## Testing
- ruff check src/ tests/
- black --check src/ tests/
- mypy src/
- pytest --cov=src/omnifocus --cov-fail-under=100 -q