### PR TITLE
chore(release): prepare v1.0.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,16 +28,26 @@ jobs:
         run: |
           printf '%s' "$GITHUB_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
-      - name: Build and push runtime image
+      - name: Enable arm64 emulation
+        run: docker run --privileged --rm tonistiigi/binfmt --install arm64
+
+      - name: Set up multi-arch builder
+        run: |
+          docker buildx create --name omnifocus-release-builder --driver docker-container --use
+          docker buildx inspect --bootstrap
+
+      - name: Build and push multi-arch runtime image
         run: |
           image="ghcr.io/${{ github.repository_owner }}/omnifocus-cli"
           version="${GITHUB_REF_NAME}"
-          docker build --file Containerfile --target runtime \
+          docker buildx build \
+            --file Containerfile \
+            --target runtime \
+            --platform linux/amd64,linux/arm64 \
             --tag "${image}:${version}" \
             --tag "${image}:latest" \
+            --push \
             .
-          docker push "${image}:${version}"
-          docker push "${image}:latest"
 
   github-release:
     name: Create GitHub Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.0.7] - 2026-03-24
+
+### Fixed
+
+- Publish GHCR runtime images as a multi-architecture manifest for both `linux/amd64` and
+  `linux/arm64`
+- Clarify in the container usage docs that `:latest` may require `podman pull` or
+  `--pull=always` when a stale local image is already cached
+
 ## [1.0.6] - 2026-03-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ podman run --rm \
 ### Inspect the CLI surface
 
 ```bash
-podman run --rm of --help
-podman run --rm of --version
+podman run --rm --pull=always of --help
+podman run --rm --pull=always of --version
 ```
 
 ## Command Model
@@ -100,6 +100,8 @@ podman run --rm -i of
 ```
 
 That is the correct shape for MCP hosts that manage a long-lived stdio subprocess.
+If you track `:latest`, prefer `podman pull` or `--pull=always` before running so a cached local
+image does not mask a newer published release.
 
 ### Claude-compatible configuration
 
@@ -153,7 +155,8 @@ The project ships as:
 - a GitHub Release with wheel and sdist artifacts
 - a GHCR runtime image published by the release workflow
 
-The runtime container is based on `python:3.14-slim` and runs as a non-root user.
+The runtime container is based on `python:3.14-slim`, runs as a non-root user, and is published
+for both `linux/amd64` and `linux/arm64`.
 PyPI publishing is intentionally out of scope for the current release process.
 
 ## Development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnifocus-cli"
-version = "1.0.6"
+version = "1.0.7"
 description = "Independent CLI and MCP server for OmniFocus 4, running in Podman"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/tests/test_package_init.py
+++ b/tests/test_package_init.py
@@ -24,10 +24,10 @@ def _load_init_module() -> ModuleType:
 
 def test_version_reads_package_metadata() -> None:
     """Package version should come from installed package metadata."""
-    with patch("importlib.metadata.version", return_value="1.0.6"):
+    with patch("importlib.metadata.version", return_value="1.0.7"):
         module = _load_init_module()
 
-    assert module.__version__ == "1.0.6"
+    assert module.__version__ == "1.0.7"
 
 
 def test_version_falls_back_when_metadata_missing() -> None:


### PR DESCRIPTION
## Summary
- publish GHCR runtime images as multi-arch manifests for amd64 and arm64
- document latest-tag pull behavior for users with cached local images
- bump package metadata and changelog to 1.0.7

## Testing
- ruff check src/ tests/
- black --check src/ tests/
- mypy src/
- pytest --cov=src/omnifocus --cov-fail-under=100 -q