### PR TITLE
chore(ci): remove temporary pip-audit CVE ignore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: pip install -e ".[dev]"
 
       - name: pip-audit
-        run: pip-audit --ignore-vuln CVE-2026-4539
+        run: pip-audit
 
       - name: Ruff
         run: ruff check src/ tests/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Changed
+
+- Remove the temporary `pip-audit` ignore for `CVE-2026-4539` now that a
+  fixed `Pygments` release is available in the resolved dependency graph
+
 ## [1.1.0] - 2026-04-07
 
 ### Added


### PR DESCRIPTION
## Summary
- remove the temporary CI ignore for CVE-2026-4539
- record the cleanup in the Unreleased changelog section
- close #19 now that pip-audit passes without the exception

## Validation
- black --check src/ tests/
- ruff check src/ tests/
- mypy src/
- pip-audit
- pytest --cov=src/omnifocus --cov-fail-under=100 -q