### PR TITLE
Add support for HTTP Digest authentication 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+- Add the `OF_WEBDAV_AUTH` environment variable to select the WebDAV HTTP
+  authentication scheme (`basic` by default, or `digest` for servers that
+  reject Basic auth with `401`)
+
 ### Changed
 
 - Remove the temporary `pip-audit` ignore for `CVE-2026-4539` now that a

--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ If you prefer to keep credentials out of the URL, pass `OF_WEBDAV_USER`,
 | `OF_WEBDAV_URL` | Yes | WebDAV bundle URL. Credentials may be embedded as `https://user:pass@host/path/`. |
 | `OF_WEBDAV_USER` | No | Explicit WebDAV username. Overrides URL-embedded credentials. |
 | `OF_WEBDAV_PASS` | No | Explicit WebDAV password. Overrides URL-embedded credentials. |
+| `OF_WEBDAV_AUTH` | No | HTTP authentication scheme: `basic` (default) or `digest`. Set to `digest` if your server rejects Basic auth with `401`. |
 | `OF_ENCRYPTION_PASSPHRASE` | No | Bundle decryption passphrase. Defaults to the WebDAV password. |
 | `OF_CACHE_DIR` | No | Cache directory. Defaults to a repo-local `.of-cache/` when detectable, otherwise `/tmp/of-cache`. |
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -12,6 +12,25 @@ of --version
 of sync
 ```
 
+## Connection and Authentication
+
+The CLI is configured entirely through environment variables. At minimum, set the WebDAV bundle
+URL and credentials:
+
+```text
+OF_WEBDAV_URL    WebDAV bundle URL (credentials may be embedded as https://user:pass@host/path/)
+OF_WEBDAV_USER   Explicit WebDAV username (overrides URL-embedded credentials)
+OF_WEBDAV_PASS   Explicit WebDAV password (overrides URL-embedded credentials)
+OF_WEBDAV_AUTH   Authentication scheme: basic (default) or digest
+```
+
+By default the client authenticates with HTTP Basic. If your WebDAV server requires Digest
+authentication (a common cause of a `401` even when the username and password are correct)
+set `OF_WEBDAV_AUTH=digest`. Any other value is rejected at startup.
+
+See the [README environment-variable table](../README.md#environment-variables) for the full list,
+including `OF_ENCRYPTION_PASSPHRASE` and `OF_CACHE_DIR`.
+
 ## Tasks
 
 ```text

--- a/docs/container.md
+++ b/docs/container.md
@@ -96,6 +96,7 @@ podman run --rm --pull=always ghcr.io/szymczag/omnifocus-cli:latest --version
 | `OF_WEBDAV_URL` | Yes | WebDAV bundle URL |
 | `OF_WEBDAV_USER` | No | Explicit WebDAV username |
 | `OF_WEBDAV_PASS` | No | Explicit WebDAV password |
+| `OF_WEBDAV_AUTH` | No | WebDAV authentication scheme: `basic` (default) or `digest` |
 | `OF_ENCRYPTION_PASSPHRASE` | No | Bundle decryption passphrase |
 | `OF_CACHE_DIR` | No | Writable cache directory |
 | `OF_HTTP_HOST` | No | HTTPS API bind host (default `127.0.0.1`) |

--- a/docs/http.md
+++ b/docs/http.md
@@ -36,6 +36,7 @@ The HTTPS API is intentionally strict:
 | `OF_WEBDAV_URL` | Usually | Required for endpoints that need bundle access. |
 | `OF_WEBDAV_USER` | No | Explicit WebDAV username override. |
 | `OF_WEBDAV_PASS` | No | Explicit WebDAV password override. |
+| `OF_WEBDAV_AUTH` | No | WebDAV authentication scheme: `basic` (default) or `digest`. |
 | `OF_ENCRYPTION_PASSPHRASE` | No | Bundle decryption passphrase. |
 | `OF_CACHE_DIR` | No | Writable cache directory. |
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -44,6 +44,9 @@ podman run --rm -i of mcp
 }
 ```
 
+If your WebDAV server requires Digest authentication rather than Basic, add
+`-e OF_WEBDAV_AUTH=digest` to the `args` list (the default is `basic`).
+
 ## Tool Surface
 
 ### Tasks

--- a/src/omnifocus/cli.py
+++ b/src/omnifocus/cli.py
@@ -63,6 +63,7 @@ Environment:
   OF_WEBDAV_URL             WebDAV bundle URL (required)
   OF_WEBDAV_USER            WebDAV username (optional override)
   OF_WEBDAV_PASS            WebDAV password (optional override)
+  OF_WEBDAV_AUTH            WebDAV authentication scheme: 'basic' (default) or 'digest'
   OF_ENCRYPTION_PASSPHRASE  Encryption passphrase (defaults to WebDAV password)
   OF_CACHE_DIR              Cache directory (default: /tmp/of-cache)
 

--- a/src/omnifocus/sync/webdav.py
+++ b/src/omnifocus/sync/webdav.py
@@ -39,6 +39,10 @@ _MAX_RETRIES = 3
 # Base delay in seconds between retries (doubles each attempt)
 _RETRY_BASE_DELAY = 0.5
 
+# Supported HTTP authentication schemes (selected via OF_WEBDAV_AUTH)
+_DEFAULT_AUTH_METHOD = "basic"
+_VALID_AUTH_METHODS = ("basic", "digest")
+
 
 class WebDAVClient:
     """Async WebDAV client scoped to a single ``.ofocus`` bundle directory.
@@ -47,9 +51,12 @@ class WebDAVClient:
         base_url: Full URL to the directory containing bundle files,
             e.g. ``https://dav.example.com/omnifocus/OmniFocus.ofocus/``.
             A trailing slash is required.
-        username: WebDAV Basic Auth username.
-        password: WebDAV Basic Auth password.  Never logged.
+        username: WebDAV auth username.
+        password: WebDAV auth password.  Never logged.
         timeout: HTTP request timeout in seconds.
+        auth_method: HTTP authentication scheme, ``"basic"`` (default) or
+            ``"digest"``.  The value is case-insensitive; anything else raises
+            :class:`~omnifocus.errors.OFWebDAVError`.
     """
 
     def __init__(
@@ -58,12 +65,26 @@ class WebDAVClient:
         username: str,
         password: str,
         timeout: float = 30.0,
+        auth_method: str = _DEFAULT_AUTH_METHOD,
     ) -> None:
         if not base_url.endswith("/"):
             base_url += "/"
         self._base_url = base_url
+
+        normalized = (auth_method or _DEFAULT_AUTH_METHOD).strip().lower()
+        if normalized not in _VALID_AUTH_METHODS:
+            raise OFWebDAVError(
+                f"Unsupported WebDAV auth method: {auth_method!r}. "
+                f"Set OF_WEBDAV_AUTH to one of: {', '.join(_VALID_AUTH_METHODS)}."
+            )
+        self._auth_method = normalized
+        auth: httpx.Auth = (
+            httpx.DigestAuth(username, password)
+            if normalized == "digest"
+            else httpx.BasicAuth(username, password)
+        )
         self._client = httpx.AsyncClient(
-            auth=(username, password),
+            auth=auth,
             timeout=httpx.Timeout(timeout),
             follow_redirects=True,
         )
@@ -100,9 +121,14 @@ class WebDAVClient:
             OF_WEBDAV_USER: Username (overrides URL-embedded user).
             OF_WEBDAV_PASS: Password (overrides URL-embedded password).
 
+        Optional variables:
+            OF_WEBDAV_AUTH: Authentication scheme, ``basic`` (default) or
+                ``digest``.
+
         Raises:
-            OFWebDAVError: If ``OF_WEBDAV_URL`` is missing, or if credentials
-                cannot be found in either the URL or the separate variables.
+            OFWebDAVError: If ``OF_WEBDAV_URL`` is missing, if credentials
+                cannot be found in either the URL or the separate variables,
+                or if ``OF_WEBDAV_AUTH`` names an unsupported scheme.
         """
         raw_url = os.environ.get("OF_WEBDAV_URL", "")
         if not raw_url:
@@ -134,7 +160,14 @@ class WebDAVClient:
         if missing:
             raise OFWebDAVError(f"Missing required environment variables: {', '.join(missing)}")
 
-        return cls(base_url=clean_url, username=username, password=password)
+        auth_method = os.environ.get("OF_WEBDAV_AUTH") or _DEFAULT_AUTH_METHOD
+
+        return cls(
+            base_url=clean_url,
+            username=username,
+            password=password,
+            auth_method=auth_method,
+        )
 
     # ------------------------------------------------------------------
     # Core operations

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -7,6 +7,8 @@ __author__ = "Maciej Szymczak <maciej@szymczak.at>"
 import asyncio
 import dataclasses
 import json
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -58,6 +60,26 @@ from omnifocus.mcp_server import (
 from omnifocus.models import Folder, OFModel, Project, Tag, Task
 
 NOW = datetime(2026, 3, 22, 12, 0, 0, tzinfo=UTC)
+# Reference "today" for the due/today task filters. Chosen after t1's due date
+# (2026-04-01) so that t1 reads as overdue while t2 is due exactly today.
+TODAY = datetime(2026, 4, 15, 12, 0, 0, tzinfo=UTC)
+
+
+@contextmanager
+def _frozen_review_clock(model: OFModel) -> Iterator[None]:
+    """Patch the loaded model and pin the review clock to ``NOW``.
+
+    Review-due state is computed against ``datetime.now(UTC)`` in the service
+    layer, so the fixture's review timestamps (which treat ``NOW`` as "today")
+    only behave as intended when the clock is pinned. Pinning keeps the
+    due/not-due split deterministic regardless of the real wall-clock date.
+    """
+    with (
+        patch("omnifocus.mcp_server._load_model", AsyncMock(return_value=model)),
+        patch("omnifocus.api_service.datetime") as mock_datetime,
+    ):
+        mock_datetime.now.return_value = NOW
+        yield
 
 
 # ---------------------------------------------------------------------------
@@ -160,7 +182,7 @@ def _make_model() -> OFModel:
         inbox=True,
         completed=None,
         flagged=False,
-        due=datetime.today().replace(hour=19, minute=0, second=0, microsecond=0),
+        due=TODAY.replace(tzinfo=None, hour=19, minute=0, second=0, microsecond=0),
         start=None,
         hidden=None,
         note="",
@@ -343,10 +365,16 @@ class TestHandleListTasks:
 
     @pytest.mark.asyncio
     async def test_today_filter(self) -> None:
-        with patch("omnifocus.mcp_server._load_model", AsyncMock(return_value=_make_model())):
+        # The "today" filter compares due dates against datetime.today(); pin it
+        # so the due-today (t2) and overdue (t1) split stays deterministic.
+        with (
+            patch("omnifocus.mcp_server._load_model", AsyncMock(return_value=_make_model())),
+            patch("omnifocus.api_service.datetime") as mock_datetime,
+        ):
+            mock_datetime.today.return_value = TODAY
             result = await _handle_list_tasks({"today": True})
         data = _parse_response(result)
-        # "today" includes tasks due today and overdue tasks.
+        # "today" includes tasks due today (t2) and overdue tasks (t1).
         assert {task["id"] for task in data} == {"t1", "t2"}
 
     @pytest.mark.asyncio
@@ -1056,7 +1084,7 @@ class TestHandleListProjects:
 class TestHandleListProjectsForReview:
     @pytest.mark.asyncio
     async def test_returns_due_review_projects_only_by_default(self) -> None:
-        with patch("omnifocus.mcp_server._load_model", AsyncMock(return_value=_make_model())):
+        with _frozen_review_clock(_make_model()):
             result = await _handle_list_projects_for_review({})
         data = _parse_response(result)
         assert [project["id"] for project in data] == ["p1", "p3"]
@@ -1064,7 +1092,7 @@ class TestHandleListProjectsForReview:
 
     @pytest.mark.asyncio
     async def test_can_include_non_due_review_projects(self) -> None:
-        with patch("omnifocus.mcp_server._load_model", AsyncMock(return_value=_make_model())):
+        with _frozen_review_clock(_make_model()):
             result = await _handle_list_projects_for_review({"due_only": False})
         data = _parse_response(result)
         assert {project["id"] for project in data} == {"p1", "p2", "p3"}
@@ -1080,7 +1108,7 @@ class TestHandleListProjectsForReview:
             next_review=None,
             review_interval="bogus",
         )
-        with patch("omnifocus.mcp_server._load_model", AsyncMock(return_value=model)):
+        with _frozen_review_clock(model):
             result = await _handle_list_projects_for_review({"due_only": False})
         data = _parse_response(result)
         assert data[-1]["id"] == "p4"

--- a/tests/test_webdav.py
+++ b/tests/test_webdav.py
@@ -131,6 +131,79 @@ class TestFromEnv:
 
 
 # ---------------------------------------------------------------------------
+# Authentication scheme selection (OF_WEBDAV_AUTH)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthMethod:
+    def test_default_is_basic(self) -> None:
+        client = WebDAVClient(BASE_URL, "u", "p")
+        assert client._auth_method == "basic"
+        assert isinstance(client._client._auth, httpx.BasicAuth)
+
+    def test_explicit_digest(self) -> None:
+        client = WebDAVClient(BASE_URL, "u", "p", auth_method="digest")
+        assert client._auth_method == "digest"
+        assert isinstance(client._client._auth, httpx.DigestAuth)
+
+    def test_value_is_case_insensitive(self) -> None:
+        client = WebDAVClient(BASE_URL, "u", "p", auth_method="DIGEST")
+        assert client._auth_method == "digest"
+
+    def test_invalid_method_raises(self) -> None:
+        with pytest.raises(OFWebDAVError, match="Unsupported WebDAV auth method"):
+            WebDAVClient(BASE_URL, "u", "p", auth_method="ntlm")
+
+    def test_from_env_defaults_to_basic(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OF_WEBDAV_URL", BASE_URL)
+        monkeypatch.setenv("OF_WEBDAV_USER", "u")
+        monkeypatch.setenv("OF_WEBDAV_PASS", "p")
+        monkeypatch.delenv("OF_WEBDAV_AUTH", raising=False)
+        client = WebDAVClient.from_env()
+        assert client._auth_method == "basic"
+
+    def test_from_env_selects_digest(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OF_WEBDAV_URL", BASE_URL)
+        monkeypatch.setenv("OF_WEBDAV_USER", "u")
+        monkeypatch.setenv("OF_WEBDAV_PASS", "p")
+        monkeypatch.setenv("OF_WEBDAV_AUTH", "digest")
+        client = WebDAVClient.from_env()
+        assert client._auth_method == "digest"
+        assert isinstance(client._client._auth, httpx.DigestAuth)
+
+    def test_from_env_invalid_auth_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OF_WEBDAV_URL", BASE_URL)
+        monkeypatch.setenv("OF_WEBDAV_USER", "u")
+        monkeypatch.setenv("OF_WEBDAV_PASS", "p")
+        monkeypatch.setenv("OF_WEBDAV_AUTH", "kerberos")
+        with pytest.raises(OFWebDAVError, match="OF_WEBDAV_AUTH"):
+            WebDAVClient.from_env()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_digest_auth_responds_to_challenge(self) -> None:
+        """A digest client must answer a 401 challenge and resend with credentials."""
+        url = BASE_URL + "file.zip"
+        challenge = (
+            'Digest realm="test", qop="auth", '
+            'nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093", '
+            'opaque="5ccc069c403ebaf9f0171e9517f40e41", algorithm=MD5'
+        )
+        route = respx.get(url).mock(
+            side_effect=[
+                httpx.Response(401, headers={"WWW-Authenticate": challenge}),
+                httpx.Response(200, content=b"ok"),
+            ]
+        )
+        async with WebDAVClient(BASE_URL, "user", "pass", auth_method="digest") as client:
+            data = await client.get_file("file.zip")
+        assert data == b"ok"
+        # httpx performs the challenge/response handshake within a single request call.
+        assert route.call_count == 2
+        assert route.calls.last.request.headers["Authorization"].startswith("Digest ")
+
+
+# ---------------------------------------------------------------------------
 # list_bundle
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
* Add support for HTTP Digest authentication (required for some WebDAV servers, including the Omni Sync Server from The Omni Group)
* Fix time bomb tests