### PR TITLE
Secure OmniFocus MCP HTTP deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,17 @@ mkdir -p .of-cache
 podman run --rm \
   -v "$PWD/.of-cache":/cache \
   -e OF_CACHE_DIR=/cache \
-  -e OF_WEBDAV_URL=https://user:pass@dav.example.com/OmniFocus.ofocus/ \
+  -e OF_WEBDAV_URL \
+  -e OF_WEBDAV_USER \
+  -e OF_WEBDAV_PASS \
   of sync
 
 podman run --rm \
   -v "$PWD/.of-cache":/cache \
   -e OF_CACHE_DIR=/cache \
-  -e OF_WEBDAV_URL=https://user:pass@dav.example.com/OmniFocus.ofocus/ \
+  -e OF_WEBDAV_URL \
+  -e OF_WEBDAV_USER \
+  -e OF_WEBDAV_PASS \
   of tasks --inbox
 ```
 
@@ -77,7 +81,9 @@ podman run --rm \
 podman run --rm -i \
   -v "$PWD/.of-cache":/cache \
   -e OF_CACHE_DIR=/cache \
-  -e OF_WEBDAV_URL=https://user:pass@dav.example.com/OmniFocus.ofocus/ \
+  -e OF_WEBDAV_URL \
+  -e OF_WEBDAV_USER \
+  -e OF_WEBDAV_PASS \
   of
 ```
 
@@ -190,7 +196,11 @@ image does not mask a newer published release.
         "-e",
         "OF_CACHE_DIR=/cache",
         "-e",
-        "OF_WEBDAV_URL=https://user:pass@dav.example.com/OmniFocus.ofocus/",
+        "OF_WEBDAV_URL",
+        "-e",
+        "OF_WEBDAV_USER",
+        "-e",
+        "OF_WEBDAV_PASS",
         "of:latest"
       ]
     }
@@ -198,8 +208,8 @@ image does not mask a newer published release.
 }
 ```
 
-If you prefer to keep credentials out of the URL, pass `OF_WEBDAV_USER`,
-`OF_WEBDAV_PASS`, and optionally `OF_ENCRYPTION_PASSPHRASE` as separate variables.
+Set the variables in your MCP host's explicit environment configuration; do not put credential
+values in command arguments or embed them in `OF_WEBDAV_URL`.
 
 ### MCP deployment notes
 
@@ -211,11 +221,15 @@ If you prefer to keep credentials out of the URL, pass `OF_WEBDAV_USER`,
 
 | Variable | Required | Description |
 | --- | --- | --- |
-| `OF_WEBDAV_URL` | Yes | WebDAV bundle URL. Credentials may be embedded as `https://user:pass@host/path/`. |
+| `OF_WEBDAV_URL` | Yes | WebDAV bundle URL. Embedded credentials remain supported for compatibility but are not recommended. |
 | `OF_WEBDAV_USER` | No | Explicit WebDAV username. Overrides URL-embedded credentials. |
 | `OF_WEBDAV_PASS` | No | Explicit WebDAV password. Overrides URL-embedded credentials. |
 | `OF_ENCRYPTION_PASSPHRASE` | No | Bundle decryption passphrase. Defaults to the WebDAV password. |
 | `OF_CACHE_DIR` | No | Cache directory. Defaults to a repo-local `.of-cache/` when detectable, otherwise `/tmp/of-cache`. |
+
+Every sensitive variable also accepts a mutually exclusive `_FILE` form (for example,
+`OF_WEBDAV_PASS_FILE`). The file is read as UTF-8 and is suitable for a container secret mount.
+Prefer it to an environment variable or URL-embedded credentials.
 
 ## Distribution
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ podman run --rm --pull=always of --version
 ## Documentation
 
 - [CLI reference](docs/cli.md) for the exact `of` command surface
-- [HTTPS API reference](docs/http.md) for operator guidance around the `/v1` API
+- [HTTPS API reference](docs/http.md) for operator guidance, including a copy-paste local TLS and Hermes MCP setup
 - [ASVS 5.0 security mapping](docs/security/asvs-5.0.md) for implemented controls and known gaps
 - [MCP reference](docs/mcp.md) for the stdio tool catalog and input contracts
 - [Container and runtime notes](docs/container.md) for image behavior and deployment patterns

--- a/docs/container.md
+++ b/docs/container.md
@@ -35,6 +35,34 @@ podman run --rm \
   of sync
 ```
 
+## Secrets
+
+Do not embed a username or password in `OF_WEBDAV_URL`, command arguments, or checked-in
+configuration. The WebDAV URL, username, password, encryption passphrase, and HTTPS API key
+also support a mutually exclusive `_FILE` form. This is intended for mounted secret files.
+
+For a rootless Podman container, create secrets through a trusted interactive input mechanism,
+then mount them read-only for the runtime user (UID 1001):
+
+```bash
+podman secret create of-webdav-url -
+podman secret create of-webdav-user -
+podman secret create of-webdav-pass -
+
+podman run --rm -i \
+  --secret of-webdav-url,target=of-webdav-url,uid=1001,gid=1001,mode=0400 \
+  --secret of-webdav-user,target=of-webdav-user,uid=1001,gid=1001,mode=0400 \
+  --secret of-webdav-pass,target=of-webdav-pass,uid=1001,gid=1001,mode=0400 \
+  -e OF_WEBDAV_URL_FILE=/run/secrets/of-webdav-url \
+  -e OF_WEBDAV_USER_FILE=/run/secrets/of-webdav-user \
+  -e OF_WEBDAV_PASS_FILE=/run/secrets/of-webdav-pass \
+  ghcr.io/szymczag/omnifocus-cli:latest
+```
+
+Mounted Podman secrets keep their contents out of process arguments and ordinary container
+environment inspection. They do not protect against root or another principal that can read the
+running container's mounts. Rotate a secret by recreating it and recreating the container.
+
 ## CLI vs MCP
 
 - `podman run --rm of sync`
@@ -97,10 +125,15 @@ podman run --rm --pull=always ghcr.io/szymczag/omnifocus-cli:latest --version
 | `OF_WEBDAV_USER` | No | Explicit WebDAV username |
 | `OF_WEBDAV_PASS` | No | Explicit WebDAV password |
 | `OF_ENCRYPTION_PASSPHRASE` | No | Bundle decryption passphrase |
+| `OF_WEBDAV_URL_FILE` | No | File containing the WebDAV URL; conflicts with `OF_WEBDAV_URL` |
+| `OF_WEBDAV_USER_FILE` | No | File containing the WebDAV username; conflicts with `OF_WEBDAV_USER` |
+| `OF_WEBDAV_PASS_FILE` | No | File containing the WebDAV password; conflicts with `OF_WEBDAV_PASS` |
+| `OF_ENCRYPTION_PASSPHRASE_FILE` | No | File containing the decryption passphrase; conflicts with `OF_ENCRYPTION_PASSPHRASE` |
 | `OF_CACHE_DIR` | No | Writable cache directory |
 | `OF_HTTP_HOST` | No | HTTPS API bind host (default `127.0.0.1`) |
 | `OF_HTTP_PORT` | No | HTTPS API bind port (default `8443`) |
 | `OF_HTTP_API_KEY` | HTTPS only | Required Bearer token for the HTTPS API |
+| `OF_HTTP_API_KEY_FILE` | HTTPS only | File containing the Bearer token; conflicts with `OF_HTTP_API_KEY` |
 | `OF_HTTP_TLS_CERT_FILE` | HTTPS only | TLS certificate PEM path |
 | `OF_HTTP_TLS_KEY_FILE` | HTTPS only | TLS private key PEM path |
 | `OF_HTTP_ALLOWED_HOSTS` | HTTPS only | Comma-separated trusted host allowlist |

--- a/docs/http.md
+++ b/docs/http.md
@@ -30,6 +30,7 @@ The HTTPS API is intentionally strict:
 | `OF_HTTP_HOST` | No | Bind host. Defaults to `127.0.0.1`. |
 | `OF_HTTP_PORT` | No | Bind port. Defaults to `8443`. |
 | `OF_HTTP_API_KEY` | Yes | Required Bearer token value. |
+| `OF_HTTP_API_KEY_FILE` | No | File containing the Bearer token; conflicts with `OF_HTTP_API_KEY`. |
 | `OF_HTTP_TLS_CERT_FILE` | Yes | Path to the TLS certificate PEM file. |
 | `OF_HTTP_TLS_KEY_FILE` | Yes | Path to the TLS private key PEM file. |
 | `OF_HTTP_ALLOWED_HOSTS` | No | Comma-separated trusted host allowlist. Defaults to `127.0.0.1,localhost`. |
@@ -38,6 +39,86 @@ The HTTPS API is intentionally strict:
 | `OF_WEBDAV_PASS` | No | Explicit WebDAV password override. |
 | `OF_ENCRYPTION_PASSPHRASE` | No | Bundle decryption passphrase. |
 | `OF_CACHE_DIR` | No | Writable cache directory. |
+
+## Copy-paste localhost TLS and Hermes MCP setup
+
+This creates a self-signed server certificate that is trusted only by Hermes. It has Subject
+Alternative Names for both `localhost` and `127.0.0.1`; use `https://localhost:8443/mcp/` in the
+Hermes configuration so normal hostname validation succeeds. This is preferable to disabling
+verification or pinning a certificate fingerprint.
+
+Run once on the host that runs both Podman and Hermes:
+
+```bash
+umask 077
+TLS_DIR="$HOME/.config/omnifocus-mcp/tls"
+mkdir -p "$TLS_DIR"
+mkdir -p "$HOME/.local/share/omnifocus-mcp-cache"
+chmod 700 "$HOME/.local/share/omnifocus-mcp-cache"
+
+openssl genpkey -algorithm ED25519 -out "$TLS_DIR/server-key.pem"
+openssl req -x509 -new -sha256 -days 397 \
+  -key "$TLS_DIR/server-key.pem" \
+  -out "$TLS_DIR/server-cert.pem" \
+  -subj '/CN=localhost' \
+  -addext 'subjectAltName=DNS:localhost,IP:127.0.0.1' \
+  -addext 'basicConstraints=critical,CA:FALSE' \
+  -addext 'keyUsage=critical,digitalSignature' \
+  -addext 'extendedKeyUsage=serverAuth'
+openssl rand -hex 32 > "$TLS_DIR/api-token"
+chmod 600 "$TLS_DIR/server-key.pem" "$TLS_DIR/api-token"
+
+podman secret create of-http-api-key "$TLS_DIR/api-token"
+```
+
+Create the WebDAV secrets as described in [Container and Runtime Notes](container.md#secrets),
+then start one long-lived local service:
+
+```bash
+podman run --rm -d --name omnifocus-mcp \
+  -p 127.0.0.1:8443:8443 \
+  -v "$TLS_DIR":/tls:ro \
+  -v "$HOME/.local/share/omnifocus-mcp-cache":/cache \
+  --secret of-http-api-key,target=of-http-api-key,uid=1001,gid=1001,mode=0400 \
+  --secret of-webdav-url,target=of-webdav-url,uid=1001,gid=1001,mode=0400 \
+  --secret of-webdav-user,target=of-webdav-user,uid=1001,gid=1001,mode=0400 \
+  --secret of-webdav-pass,target=of-webdav-pass,uid=1001,gid=1001,mode=0400 \
+  -e OF_CACHE_DIR=/cache \
+  -e OF_HTTP_API_KEY_FILE=/run/secrets/of-http-api-key \
+  -e OF_HTTP_TLS_CERT_FILE=/tls/server-cert.pem \
+  -e OF_HTTP_TLS_KEY_FILE=/tls/server-key.pem \
+  -e OF_WEBDAV_URL_FILE=/run/secrets/of-webdav-url \
+  -e OF_WEBDAV_USER_FILE=/run/secrets/of-webdav-user \
+  -e OF_WEBDAV_PASS_FILE=/run/secrets/of-webdav-pass \
+  ghcr.io/szymczag/omnifocus-cli:latest http
+```
+
+Add the following token reference to `~/.hermes/.env` without putting the token in
+`config.yaml`:
+
+```bash
+printf '\nOMNIFOCUS_MCP_TOKEN=%s\n' "$(<"$TLS_DIR/api-token")" >> "$HOME/.hermes/.env"
+chmod 600 "$HOME/.hermes/.env"
+```
+
+Then add this to `~/.hermes/config.yaml` and reload MCP configuration in Hermes:
+
+```yaml
+mcp_servers:
+  omnifocus:
+    url: https://localhost:8443/mcp/
+    ssl_verify: ~/.config/omnifocus-mcp/tls/server-cert.pem
+    headers:
+      Authorization: Bearer ${OMNIFOCUS_MCP_TOKEN}
+    tools:
+      resources: false
+      prompts: false
+```
+
+The `/mcp/` endpoint is server-enforced read-only. The same Bearer token is required for every
+request, including MCP initialization and tool discovery. Keep the service bound to `127.0.0.1`;
+do not use this self-signed setup for a remotely reachable service. To rotate the certificate or
+token, recreate the relevant file/Podman secret, recreate the container, and reload Hermes.
 
 ## Start the Server
 
@@ -75,7 +156,7 @@ and implementation summary.
 Example:
 
 ```bash
-curl --silent --show-error --insecure \
+curl --silent --show-error --cacert /absolute/path/to/server-cert.pem \
   -H "Authorization: Bearer replace-me" \
   https://127.0.0.1:8443/v1/openapi.json
 ```
@@ -88,12 +169,12 @@ Use the standard HTTP Request node:
 - URL: `https://127.0.0.1:8443/v1/...`
 - Authentication: Header auth
 - Header: `Authorization: Bearer <your-token>`
-- TLS: trust your certificate or disable verification only in a controlled local setup
+- TLS: trust the local certificate with the client's CA/certificate configuration; do not disable verification
 
 Minimal example:
 
 ```bash
-curl --silent --show-error --insecure \
+curl --silent --show-error --cacert /absolute/path/to/server-cert.pem \
   -H "Authorization: Bearer replace-me" \
   https://127.0.0.1:8443/v1/health
 ```

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -16,6 +16,9 @@ podman run --rm -i of mcp
 
 ## Host Configuration
 
+For an MCP host that passes selected environment variables to `podman`, use variable names rather
+than secret values in the argument list:
+
 ```json
 {
   "mcpServers": {
@@ -43,6 +46,38 @@ podman run --rm -i of mcp
   }
 }
 ```
+
+### Podman secret mounts
+
+For local deployments, mount Podman secrets and pass only their in-container paths. The image runs
+as UID 1001, so mounts must be readable by that user:
+
+```yaml
+mcp_servers:
+  omnifocus:
+    command: podman
+    args:
+      - run
+      - --rm
+      - -i
+      - --secret
+      - of-webdav-url,target=of-webdav-url,uid=1001,gid=1001,mode=0400
+      - --secret
+      - of-webdav-user,target=of-webdav-user,uid=1001,gid=1001,mode=0400
+      - --secret
+      - of-webdav-pass,target=of-webdav-pass,uid=1001,gid=1001,mode=0400
+      - -e
+      - OF_WEBDAV_URL_FILE=/run/secrets/of-webdav-url
+      - -e
+      - OF_WEBDAV_USER_FILE=/run/secrets/of-webdav-user
+      - -e
+      - OF_WEBDAV_PASS_FILE=/run/secrets/of-webdav-pass
+      - of:latest
+```
+
+Create each secret from a trusted interactive input channel with `podman secret create NAME -`.
+Avoid URL-embedded credentials: they appear in process arguments and are easy to leak through
+configuration, logs, and shell history.
 
 ## Tool Surface
 

--- a/src/omnifocus/api_service.py
+++ b/src/omnifocus/api_service.py
@@ -152,6 +152,7 @@ class StoreBackedApiService:
         name: str,
         project_id: str | None = None,
         parent_task_id: str | None = None,
+        validation_model: OFModel | None = None,
         due: str | None = None,
         defer: str | None = None,
         flagged: bool = False,
@@ -187,7 +188,7 @@ class StoreBackedApiService:
         resolved_parent: str | None = None
         inbox = True
         if project_id is not None:
-            model = await self._load_model(False)
+            model = validation_model or await self._load_model(False)
             project = self._require_project(model, project_id)
             if project.status in {"done", "dropped"}:
                 raise OFHTTPError(
@@ -198,7 +199,7 @@ class StoreBackedApiService:
             resolved_parent = project.id
             inbox = False
         elif parent_task_id is not None:
-            model = await self._load_model(False)
+            model = validation_model or await self._load_model(False)
             self._require_parent(model, parent_task_id)
             resolved_parent = parent_task_id
             inbox = False
@@ -327,6 +328,7 @@ class StoreBackedApiService:
         *,
         name: str,
         folder_id: str | None = None,
+        validation_model: OFModel | None = None,
         due: str | None = None,
         defer: str | None = None,
         flagged: bool = False,
@@ -343,7 +345,7 @@ class StoreBackedApiService:
                 code="validation_error",
             )
         if folder_id is not None:
-            model = await self._load_model(False)
+            model = validation_model or await self._load_model(False)
             self._require_folder(model, folder_id)
         async with self._store_factory() as store:
             return await store.add_project(

--- a/src/omnifocus/cli.py
+++ b/src/omnifocus/cli.py
@@ -61,9 +61,13 @@ Author: Maciej Szymczak <maciej@szymczak.at>
 
 Environment:
   OF_WEBDAV_URL             WebDAV bundle URL (required)
+  OF_WEBDAV_URL_FILE        File containing the WebDAV bundle URL
   OF_WEBDAV_USER            WebDAV username (optional override)
+  OF_WEBDAV_USER_FILE       File containing the WebDAV username
   OF_WEBDAV_PASS            WebDAV password (optional override)
+  OF_WEBDAV_PASS_FILE       File containing the WebDAV password
   OF_ENCRYPTION_PASSPHRASE  Encryption passphrase (defaults to WebDAV password)
+  OF_ENCRYPTION_PASSPHRASE_FILE  File containing the encryption passphrase
   OF_CACHE_DIR              Cache directory (default: /tmp/of-cache)
 
 Common commands:

--- a/src/omnifocus/env.py
+++ b/src/omnifocus/env.py
@@ -1,0 +1,32 @@
+"""Safe configuration readers for environment variables and secret files."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from omnifocus.errors import OFError
+
+
+def read_env_or_file[ErrorT: OFError](name: str, *, error_type: type[ErrorT]) -> str | None:
+    """Read *name* directly or from ``<name>_FILE`` without exposing its value.
+
+    The ``_FILE`` form is intended for container secret mounts.  Supplying both
+    forms is rejected so a stale environment variable cannot silently override
+    a rotated secret file.  A single final line ending is removed because
+    secret-management CLIs commonly write one.
+    """
+
+    file_name = f"{name}_FILE"
+    value = os.environ.get(name)
+    file_path = os.environ.get(file_name)
+    if value is not None and file_path is not None:
+        raise error_type(f"{name} and {file_name} cannot both be set")
+    if file_path is None:
+        return value
+
+    try:
+        secret = Path(file_path).read_text(encoding="utf-8")
+    except OSError as exc:
+        raise error_type(f"Unable to read secret file configured by {file_name}") from exc
+    return secret.removesuffix("\n").removesuffix("\r")

--- a/src/omnifocus/http_api.py
+++ b/src/omnifocus/http_api.py
@@ -20,7 +20,7 @@ import time
 import uuid
 from collections import deque
 from collections.abc import Sequence
-from contextlib import suppress
+from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -40,6 +40,7 @@ from omnifocus import __version__
 from omnifocus.api_service import StoreBackedApiService, default_api_service
 from omnifocus.env import read_env_or_file
 from omnifocus.errors import OFError, OFHTTPError
+from omnifocus.mcp_http import ReadOnlyMCPHTTPApp
 
 _MAX_JSON_BODY_BYTES = 1024 * 1024
 _DEFAULT_ALLOWED_HOSTS = ("127.0.0.1", "localhost")
@@ -1012,6 +1013,7 @@ def create_app(
     auth_failure_limit: int = _AUTH_FAILURE_LIMIT,
     auth_failure_window_seconds: float = _AUTH_FAILURE_WINDOW_SECONDS,
     request_timeout_seconds: float = _DEFAULT_REQUEST_TIMEOUT_SECONDS,
+    enable_mcp: bool = False,
 ) -> FastAPI:
     """Create the FastAPI HTTPS application."""
 
@@ -1020,6 +1022,15 @@ def create_app(
         raise OFError("At least one HTTP API key is required")
     resolved_service = default_api_service() if service is None else service
     resolved_allowed_hosts = tuple(allowed_hosts or _DEFAULT_ALLOWED_HOSTS)
+    mcp_app = ReadOnlyMCPHTTPApp() if enable_mcp else None
+
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI) -> Any:
+        if mcp_app is None:
+            yield
+            return
+        async with mcp_app.lifespan():
+            yield
 
     app = FastAPI(
         title="OmniFocus HTTPS API",
@@ -1027,8 +1038,11 @@ def create_app(
         docs_url=None,
         redoc_url=None,
         openapi_url="/v1/openapi.json",
+        lifespan=lifespan,
     )
     _configure_openapi(app)
+    if mcp_app is not None:
+        app.mount("/mcp", mcp_app)
 
     @app.exception_handler(OFError)
     async def of_error_handler(_request: Request, exc: Exception) -> JSONResponse:
@@ -1548,6 +1562,7 @@ async def _serve_uvicorn(
         api_keys=config.api_keys,
         allowed_hosts=config.allowed_hosts,
         service=service,
+        enable_mcp=True,
     )
     uvicorn_config = uvicorn.Config(
         app,

--- a/src/omnifocus/http_api.py
+++ b/src/omnifocus/http_api.py
@@ -38,6 +38,7 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 
 from omnifocus import __version__
 from omnifocus.api_service import StoreBackedApiService, default_api_service
+from omnifocus.env import read_env_or_file
 from omnifocus.errors import OFError, OFHTTPError
 
 _MAX_JSON_BODY_BYTES = 1024 * 1024
@@ -74,7 +75,7 @@ class HTTPServerConfig:
     def from_env(cls) -> HTTPServerConfig:
         """Load and validate HTTPS API configuration from environment variables."""
 
-        api_key = os.getenv("OF_HTTP_API_KEY")
+        api_key = read_env_or_file("OF_HTTP_API_KEY", error_type=OFError)
         cert_path = os.getenv("OF_HTTP_TLS_CERT_FILE")
         key_path = os.getenv("OF_HTTP_TLS_KEY_FILE")
         missing = [

--- a/src/omnifocus/mcp_http.py
+++ b/src/omnifocus/mcp_http.py
@@ -1,0 +1,48 @@
+"""Read-only Streamable HTTP transport for the OmniFocus MCP server."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Awaitable, Callable, MutableMapping
+from contextlib import asynccontextmanager
+from typing import Any
+
+from mcp.server.streamable_http import StreamableHTTPServerTransport
+
+from omnifocus.mcp_server import read_only_server
+
+Scope = MutableMapping[str, Any]
+Receive = Callable[[], Awaitable[Scope]]
+Send = Callable[[Scope], Awaitable[None]]
+
+
+class ReadOnlyMCPHTTPApp:
+    """ASGI adapter and lifespan owner for a stateless read-only MCP server."""
+
+    def __init__(self) -> None:
+        self._transport = StreamableHTTPServerTransport(
+            mcp_session_id=None,
+            is_json_response_enabled=True,
+        )
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Handle one Streamable HTTP MCP request."""
+        await self._transport.handle_request(scope, receive, send)
+
+    @asynccontextmanager
+    async def lifespan(self) -> AsyncIterator[None]:
+        """Run the low-level MCP server for the lifetime of the ASGI application."""
+        async with self._transport.connect() as (read_stream, write_stream):
+            server_task = asyncio.create_task(
+                read_only_server.run(
+                    read_stream,
+                    write_stream,
+                    read_only_server.create_initialization_options(),
+                    stateless=True,
+                )
+            )
+            try:
+                yield
+            finally:
+                await self._transport.terminate()
+                await server_task

--- a/src/omnifocus/mcp_server.py
+++ b/src/omnifocus/mcp_server.py
@@ -94,6 +94,23 @@ from omnifocus.store import OFocusStore
 # ---------------------------------------------------------------------------
 
 server: Server = Server("omnifocus")
+read_only_server: Server = Server("omnifocus-read-only")
+
+_READ_ONLY_TOOL_NAMES = frozenset(
+    {
+        "list_tasks",
+        "search_tasks",
+        "get_task",
+        "get_project",
+        "list_projects",
+        "list_projects_for_review",
+        "list_folders",
+        "get_folder",
+        "get_folder_tree",
+        "list_tags",
+        "get_tag",
+    }
+)
 
 
 # ---------------------------------------------------------------------------
@@ -571,6 +588,12 @@ async def list_tools() -> list[Tool]:
 # ---------------------------------------------------------------------------
 
 
+@read_only_server.list_tools()  # type: ignore[no-untyped-call, untyped-decorator]
+async def list_read_only_tools() -> list[Tool]:
+    """List the server-enforced read-only MCP tool surface."""
+    return [tool for tool in await list_tools() if tool.name in _READ_ONLY_TOOL_NAMES]
+
+
 @server.call_tool()  # type: ignore[untyped-decorator]
 async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
     """Dispatch incoming tool calls to the appropriate handler."""
@@ -609,6 +632,14 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
         return await typed_handler(arguments)
     except OFError as exc:
         return _text({"error": str(exc)})
+
+
+@read_only_server.call_tool()  # type: ignore[untyped-decorator]
+async def call_read_only_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+    """Dispatch only read-only tools for the network MCP transport."""
+    if name not in _READ_ONLY_TOOL_NAMES:
+        return _text({"error": f"Tool is not available from the read-only server: {name}"})
+    return await call_tool(name, arguments)
 
 
 async def _handle_list_tasks(args: dict[str, Any]) -> list[TextContent]:

--- a/src/omnifocus/mcp_server.py
+++ b/src/omnifocus/mcp_server.py
@@ -663,6 +663,7 @@ async def _handle_add_task(args: dict[str, Any]) -> list[TextContent]:
             name=str(args.get("name", "")),
             project_id=project_id,
             parent_task_id=str(args["parent_task_id"]) if "parent_task_id" in args else None,
+            validation_model=model,
             due=str(args["due"]) if "due" in args else None,
             defer=str(args["defer"]) if "defer" in args else None,
             flagged=bool(args.get("flagged", False)),
@@ -733,6 +734,7 @@ async def _handle_add_project(args: dict[str, Any]) -> list[TextContent]:
         _service().add_project(
             name=str(args.get("name", "")),
             folder_id=folder_id,
+            validation_model=model,
             due=str(args["due"]) if "due" in args else None,
             defer=str(args["defer"]) if "defer" in args else None,
             flagged=bool(args.get("flagged", False)),

--- a/src/omnifocus/mcp_server.py
+++ b/src/omnifocus/mcp_server.py
@@ -639,7 +639,7 @@ async def call_read_only_tool(name: str, arguments: dict[str, Any]) -> list[Text
     """Dispatch only read-only tools for the network MCP transport."""
     if name not in _READ_ONLY_TOOL_NAMES:
         return _text({"error": f"Tool is not available from the read-only server: {name}"})
-    return await call_tool(name, arguments)
+    return cast(list[TextContent], await call_tool(name, arguments))
 
 
 async def _handle_list_tasks(args: dict[str, Any]) -> list[TextContent]:

--- a/src/omnifocus/store.py
+++ b/src/omnifocus/store.py
@@ -66,6 +66,7 @@ from typing import Any
 from urllib.parse import urlsplit
 
 from omnifocus.crypto.discovery import is_encrypted
+from omnifocus.env import read_env_or_file
 from omnifocus.errors import OFEncryptionError, OFError, OFWebDAVError
 from omnifocus.models import Folder, OFModel, Project, Tag, Task
 from omnifocus.parser import build_model
@@ -217,7 +218,9 @@ class OFocusStore:
             OFWebDAVError: If required WebDAV env vars are missing.
         """
         client = WebDAVClient.from_env()
-        passphrase = os.environ.get("OF_ENCRYPTION_PASSPHRASE") or _webdav_password_from_env()
+        passphrase = read_env_or_file(
+            "OF_ENCRYPTION_PASSPHRASE", error_type=OFWebDAVError
+        ) or _webdav_password_from_env()
         return cls(client=client, passphrase=passphrase or None)
 
     # ------------------------------------------------------------------
@@ -1381,10 +1384,10 @@ def _webdav_password_from_env() -> str:
     passphrase when ``OF_ENCRYPTION_PASSPHRASE`` is not explicitly set
     (OmniFocus *linked password* mode).
     """
-    explicit = os.environ.get("OF_WEBDAV_PASS", "")
+    explicit = read_env_or_file("OF_WEBDAV_PASS", error_type=OFWebDAVError) or ""
     if explicit:
         return explicit
-    raw_url = os.environ.get("OF_WEBDAV_URL", "")
+    raw_url = read_env_or_file("OF_WEBDAV_URL", error_type=OFWebDAVError) or ""
     return urlsplit(raw_url).password or ""
 
 

--- a/src/omnifocus/store.py
+++ b/src/omnifocus/store.py
@@ -218,9 +218,10 @@ class OFocusStore:
             OFWebDAVError: If required WebDAV env vars are missing.
         """
         client = WebDAVClient.from_env()
-        passphrase = read_env_or_file(
-            "OF_ENCRYPTION_PASSPHRASE", error_type=OFWebDAVError
-        ) or _webdav_password_from_env()
+        passphrase = (
+            read_env_or_file("OF_ENCRYPTION_PASSPHRASE", error_type=OFWebDAVError)
+            or _webdav_password_from_env()
+        )
         return cls(client=client, passphrase=passphrase or None)
 
     # ------------------------------------------------------------------

--- a/src/omnifocus/sync/webdav.py
+++ b/src/omnifocus/sync/webdav.py
@@ -20,12 +20,12 @@ __author__ = "Maciej Szymczak <maciej@szymczak.at>"
 
 import asyncio
 import logging
-import os
 from urllib.parse import urlsplit, urlunsplit
 from xml.etree import ElementTree as ET
 
 import httpx
 
+from omnifocus.env import read_env_or_file
 from omnifocus.errors import OFWebDAVError
 
 log = logging.getLogger(__name__)
@@ -104,7 +104,7 @@ class WebDAVClient:
             OFWebDAVError: If ``OF_WEBDAV_URL`` is missing, or if credentials
                 cannot be found in either the URL or the separate variables.
         """
-        raw_url = os.environ.get("OF_WEBDAV_URL", "")
+        raw_url = read_env_or_file("OF_WEBDAV_URL", error_type=OFWebDAVError) or ""
         if not raw_url:
             raise OFWebDAVError("Missing required environment variable: OF_WEBDAV_URL")
 
@@ -123,8 +123,8 @@ class WebDAVClient:
             clean_url = raw_url
 
         # Explicit env vars override URL-embedded credentials
-        username = os.environ.get("OF_WEBDAV_USER") or url_user
-        password = os.environ.get("OF_WEBDAV_PASS") or url_pass
+        username = read_env_or_file("OF_WEBDAV_USER", error_type=OFWebDAVError) or url_user
+        password = read_env_or_file("OF_WEBDAV_PASS", error_type=OFWebDAVError) or url_pass
 
         missing = []
         if not username:

--- a/tests/test_api_service.py
+++ b/tests/test_api_service.py
@@ -135,6 +135,21 @@ def _service(
 
 class TestStoreBackedApiService:
     @pytest.mark.asyncio
+    async def test_add_task_uses_supplied_validation_model(self) -> None:
+        store = AsyncMock()
+        store.add_task.return_value = {"status": "created", "task_id": "new", "name": "Task"}
+        model = _make_model()
+        load_model = AsyncMock(return_value=model)
+        service = StoreBackedApiService(
+            load_model=load_model,
+            store_factory=lambda: _store_context(store),
+        )
+
+        await service.add_task(name="Task", project_id="p2", validation_model=model)
+
+        load_model.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_add_task_allows_inactive_project(self) -> None:
         store = AsyncMock()
         store.add_task.return_value = {"status": "created", "task_id": "new", "name": "Task"}
@@ -146,6 +161,25 @@ class TestStoreBackedApiService:
         store.add_task.assert_awaited_once()
         assert store.add_task.await_args.kwargs["parent_task_id"] == "p2"
         assert store.add_task.await_args.kwargs["inbox"] is False
+
+    @pytest.mark.asyncio
+    async def test_add_project_uses_supplied_validation_model(self) -> None:
+        store = AsyncMock()
+        store.add_project.return_value = {
+            "status": "created",
+            "project_id": "new",
+            "name": "Project",
+        }
+        model = _make_model()
+        load_model = AsyncMock(return_value=model)
+        service = StoreBackedApiService(
+            load_model=load_model,
+            store_factory=lambda: _store_context(store),
+        )
+
+        await service.add_project(name="Project", folder_id="f1", validation_model=model)
+
+        load_model.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_add_task_rejects_done_project(self) -> None:

--- a/tests/test_http_api.py
+++ b/tests/test_http_api.py
@@ -348,6 +348,14 @@ def _create_client(
 
 
 class TestReadOnlyMCP:
+    def test_default_app_has_no_mcp_lifespan(self) -> None:
+        client = _create_client(_FakeService())
+
+        with client:
+            response = client.get("/v1/openapi.json", headers=_auth_headers())
+
+        assert response.status_code == 200
+
     def test_requires_bearer_authentication(self) -> None:
         client = _create_client(_FakeService(), enable_mcp=True)
 

--- a/tests/test_http_api.py
+++ b/tests/test_http_api.py
@@ -347,6 +347,41 @@ def _create_client(
     )
 
 
+class TestReadOnlyMCP:
+    def test_requires_bearer_authentication(self) -> None:
+        client = _create_client(_FakeService(), enable_mcp=True)
+
+        with client:
+            response = client.post("/mcp/", json={})
+
+        assert response.status_code == 401
+
+    def test_initializes_and_lists_read_only_tools(self) -> None:
+        client = _create_client(_FakeService(), enable_mcp=True)
+        initialize = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {"name": "test", "version": "1"},
+            },
+        }
+        list_tools = {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}
+        headers = _auth_headers(Accept="application/json, text/event-stream")
+
+        with client:
+            initialized = client.post("/mcp/", json=initialize, headers=headers)
+            tools = client.post("/mcp/", json=list_tools, headers=headers)
+
+        assert initialized.status_code == 200
+        assert tools.status_code == 200
+        names = {tool["name"] for tool in tools.json()["result"]["tools"]}
+        assert "list_tasks" in names
+        assert "add_task" not in names
+
+
 def _write_self_signed_cert(tmp_path: Path) -> tuple[Path, Path]:
     """Create a temporary self-signed certificate and private key."""
 

--- a/tests/test_http_api.py
+++ b/tests/test_http_api.py
@@ -415,6 +415,34 @@ class TestHTTPServerConfig:
 
         assert config.allowed_hosts == ("127.0.0.1", "localhost", "api.internal")
 
+    def test_from_env_reads_api_key_from_secret_file(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        cert_path, key_path = _write_self_signed_cert(tmp_path)
+        api_key_file = tmp_path / "api-key"
+        api_key_file.write_text("secret-token\n", encoding="utf-8")
+        monkeypatch.setenv("OF_HTTP_API_KEY_FILE", str(api_key_file))
+        monkeypatch.setenv("OF_HTTP_TLS_CERT_FILE", str(cert_path))
+        monkeypatch.setenv("OF_HTTP_TLS_KEY_FILE", str(key_path))
+
+        config = HTTPServerConfig.from_env()
+
+        assert config.api_key == "secret-token"
+
+    def test_from_env_rejects_api_key_and_secret_file(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        cert_path, key_path = _write_self_signed_cert(tmp_path)
+        api_key_file = tmp_path / "api-key"
+        api_key_file.write_text("secret-token", encoding="utf-8")
+        monkeypatch.setenv("OF_HTTP_API_KEY", "secret-token")
+        monkeypatch.setenv("OF_HTTP_API_KEY_FILE", str(api_key_file))
+        monkeypatch.setenv("OF_HTTP_TLS_CERT_FILE", str(cert_path))
+        monkeypatch.setenv("OF_HTTP_TLS_KEY_FILE", str(key_path))
+
+        with pytest.raises(OFError, match="OF_HTTP_API_KEY and OF_HTTP_API_KEY_FILE"):
+            HTTPServerConfig.from_env()
+
     def test_from_env_rejects_empty_allowed_hosts(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1712,6 +1712,14 @@ class TestReadOnlyServer:
 
         assert "not available from the read-only server" in result[0].text
 
+    @pytest.mark.asyncio
+    async def test_dispatches_read_tools(self) -> None:
+        expected = _text({"tasks": []})
+        with patch("omnifocus.mcp_server.call_tool", new=AsyncMock(return_value=expected)):
+            result = await call_read_only_tool("list_tasks", {})
+
+        assert result == expected
+
 
 # ---------------------------------------------------------------------------
 # _task_summary

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -51,7 +51,9 @@ from omnifocus.mcp_server import (
     _text,
     _validate_folder_parent_change,
     _validate_tag_parent_change,
+    call_read_only_tool,
     call_tool,
+    list_read_only_tools,
     list_tools,
     main,
 )
@@ -1692,6 +1694,23 @@ class TestText:
         assert result[0].type == "text"
         parsed = json.loads(result[0].text)
         assert parsed["key"] == "value"
+
+
+class TestReadOnlyServer:
+    @pytest.mark.asyncio
+    async def test_lists_only_read_tools(self) -> None:
+        tools = await list_read_only_tools()
+
+        assert tools
+        assert {tool.name for tool in tools}.isdisjoint(
+            {"add_task", "complete_task", "sync_now", "drop_folder"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_rejects_mutation_tools(self) -> None:
+        result = await call_read_only_tool("add_task", {"name": "Nope"})
+
+        assert "not available from the read-only server" in result[0].text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -203,6 +203,20 @@ class TestFromEnv:
         store = OFocusStore.from_env()
         assert store._passphrase == "secret"  # noqa: S105
 
+    def test_passphrase_reads_from_secret_file(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        passphrase_file = tmp_path / "passphrase"
+        passphrase_file.write_text("encryption-secret\n", encoding="utf-8")
+        monkeypatch.setenv("OF_WEBDAV_URL", "https://dav.example.com/of/")
+        monkeypatch.setenv("OF_WEBDAV_USER", "u")
+        monkeypatch.setenv("OF_WEBDAV_PASS", "p")
+        monkeypatch.setenv("OF_ENCRYPTION_PASSPHRASE_FILE", str(passphrase_file))
+
+        store = OFocusStore.from_env()
+
+        assert store._passphrase == "encryption-secret"  # noqa: S105
+
     def test_cache_dir_defaults_to_repo_local_dot_cache(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_webdav.py
+++ b/tests/test_webdav.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 __author__ = "Maciej Szymczak <maciej@szymczak.at>"
 
+from pathlib import Path
+
 import httpx
 import pytest
 import respx
@@ -128,6 +130,54 @@ class TestFromEnv:
         client = WebDAVClient.from_env()
         assert "8443" in client._base_url
         assert "u:p" not in client._base_url
+
+    def test_reads_credentials_from_secret_files(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        url_file = tmp_path / "url"
+        user_file = tmp_path / "user"
+        pass_file = tmp_path / "pass"
+        url_file.write_text(BASE_URL + "\n", encoding="utf-8")
+        user_file.write_text("secret-user\n", encoding="utf-8")
+        pass_file.write_text("secret-pass\n", encoding="utf-8")
+        monkeypatch.setenv("OF_WEBDAV_URL_FILE", str(url_file))
+        monkeypatch.setenv("OF_WEBDAV_USER_FILE", str(user_file))
+        monkeypatch.setenv("OF_WEBDAV_PASS_FILE", str(pass_file))
+
+        client = WebDAVClient.from_env()
+
+        assert client._base_url == BASE_URL
+        auth = client._client.auth
+        assert isinstance(auth, httpx.BasicAuth)
+        request = next(auth.auth_flow(httpx.Request("GET", BASE_URL)))
+        assert request.headers["Authorization"] == "Basic c2VjcmV0LXVzZXI6c2VjcmV0LXBhc3M="
+
+    def test_rejects_ambiguous_secret_configuration(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        secret_file = tmp_path / "pass"
+        secret_file.write_text("secret-pass", encoding="utf-8")
+        monkeypatch.setenv("OF_WEBDAV_URL", BASE_URL)
+        monkeypatch.setenv("OF_WEBDAV_USER", "user")
+        monkeypatch.setenv("OF_WEBDAV_PASS", "pass")
+        monkeypatch.setenv("OF_WEBDAV_PASS_FILE", str(secret_file))
+
+        with pytest.raises(OFWebDAVError, match="OF_WEBDAV_PASS and OF_WEBDAV_PASS_FILE"):
+            WebDAVClient.from_env()
+
+    def test_does_not_expose_secret_file_path_in_errors(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        secret_path = tmp_path / "private-password"
+        monkeypatch.setenv("OF_WEBDAV_URL", BASE_URL)
+        monkeypatch.setenv("OF_WEBDAV_USER", "user")
+        monkeypatch.setenv("OF_WEBDAV_PASS_FILE", str(secret_path))
+
+        with pytest.raises(OFWebDAVError) as exc_info:
+            WebDAVClient.from_env()
+
+        assert "OF_WEBDAV_PASS_FILE" in str(exc_info.value)
+        assert str(secret_path) not in str(exc_info.value)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add file-backed secrets and Podman secret deployment guidance
- add a server-enforced read-only Streamable HTTP MCP endpoint at /mcp/
- remove duplicate WebDAV model loads for MCP create operations
- document a copy-paste localhost TLS and Hermes setup

## Validation
- 937 tests passed in the Python 3.14 container with 100% enforced coverage