### PR TITLE
Prepare v1.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-07-17
+
+### Added
+
+- Expose a stateless, read-only Streamable HTTP MCP endpoint at `/mcp/` on the
+  existing HTTPS listener, protected by the existing bearer API key and TLS 1.3
+- Support `*_FILE` variants for sensitive configuration, including WebDAV
+  credentials, the encryption passphrase, and the HTTP API key, for safe
+  container secret mounts
+- Provide copy-paste deployment guidance for a long-lived local MCP service,
+  including a self-signed localhost TLS certificate and Hermes configuration
+
+### Changed
+
+- Reuse already-loaded OmniFocus models during MCP task and project creation to
+  avoid redundant WebDAV loads
+
+### Security
+
+- Keep the network MCP surface server-side read-only and enforce its tool
+  allowlist independently of client configuration
+- Document certificate trust-anchor verification for localhost and discourage
+  insecure TLS bypasses and URL-embedded credentials
+
 ## [1.2.0] - 2026-06-24
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnifocus-cli"
-version = "1.2.0"
+version = "1.3.0"
 description = "Independent CLI and MCP server for OmniFocus 4, running in Podman"
 readme = "README.md"
 requires-python = ">=3.14"


### PR DESCRIPTION
Updates the package version to 1.3.0 and records the released HTTPS MCP, file-backed secrets, TLS/Hermes documentation, and MCP performance changes in the changelog.