### PR TITLE
Expose full MCP tools over HTTPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-07-18
+
+### Changed
+
+- Expose the complete read/write OmniFocus MCP tool set through the authenticated HTTPS `/mcp/`
+  endpoint, matching the existing stdio MCP transport
+- Remove the temporary server-side read-only restriction from the local Hermes deployment guide
+
 ## [1.3.0] - 2026-07-17
 
 ### Added

--- a/docs/http.md
+++ b/docs/http.md
@@ -115,10 +115,12 @@ mcp_servers:
       prompts: false
 ```
 
-The `/mcp/` endpoint is server-enforced read-only. The same Bearer token is required for every
-request, including MCP initialization and tool discovery. Keep the service bound to `127.0.0.1`;
-do not use this self-signed setup for a remotely reachable service. To rotate the certificate or
-token, recreate the relevant file/Podman secret, recreate the container, and reload Hermes.
+The `/mcp/` endpoint exposes the complete OmniFocus MCP tool set, including tools that create,
+update, complete, drop, and sync OmniFocus data. The same Bearer token is required for every
+request, including MCP initialization, tool discovery, and mutations. Keep the service bound to
+`127.0.0.1`; do not use this self-signed setup for a remotely reachable service. To rotate the
+certificate or token, recreate the relevant file/Podman secret, recreate the container, and reload
+Hermes.
 
 ## Start the Server
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnifocus-cli"
-version = "1.3.0"
+version = "1.4.0"
 description = "Independent CLI and MCP server for OmniFocus 4, running in Podman"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/omnifocus/http_api.py
+++ b/src/omnifocus/http_api.py
@@ -40,7 +40,7 @@ from omnifocus import __version__
 from omnifocus.api_service import StoreBackedApiService, default_api_service
 from omnifocus.env import read_env_or_file
 from omnifocus.errors import OFError, OFHTTPError
-from omnifocus.mcp_http import ReadOnlyMCPHTTPApp
+from omnifocus.mcp_http import MCPHTTPApp
 
 _MAX_JSON_BODY_BYTES = 1024 * 1024
 _DEFAULT_ALLOWED_HOSTS = ("127.0.0.1", "localhost")
@@ -1022,7 +1022,7 @@ def create_app(
         raise OFError("At least one HTTP API key is required")
     resolved_service = default_api_service() if service is None else service
     resolved_allowed_hosts = tuple(allowed_hosts or _DEFAULT_ALLOWED_HOSTS)
-    mcp_app = ReadOnlyMCPHTTPApp() if enable_mcp else None
+    mcp_app = MCPHTTPApp() if enable_mcp else None
 
     @asynccontextmanager
     async def lifespan(_app: FastAPI) -> Any:

--- a/src/omnifocus/mcp_http.py
+++ b/src/omnifocus/mcp_http.py
@@ -1,4 +1,4 @@
-"""Read-only Streamable HTTP transport for the OmniFocus MCP server."""
+"""Streamable HTTP transport for the OmniFocus MCP server."""
 
 from __future__ import annotations
 
@@ -9,15 +9,15 @@ from typing import Any
 
 from mcp.server.streamable_http import StreamableHTTPServerTransport
 
-from omnifocus.mcp_server import read_only_server
+from omnifocus.mcp_server import server
 
 Scope = MutableMapping[str, Any]
 Receive = Callable[[], Awaitable[Scope]]
 Send = Callable[[Scope], Awaitable[None]]
 
 
-class ReadOnlyMCPHTTPApp:
-    """ASGI adapter and lifespan owner for a stateless read-only MCP server."""
+class MCPHTTPApp:
+    """ASGI adapter and lifespan owner for the stateless full MCP server."""
 
     def __init__(self) -> None:
         self._transport = StreamableHTTPServerTransport(
@@ -34,10 +34,10 @@ class ReadOnlyMCPHTTPApp:
         """Run the low-level MCP server for the lifetime of the ASGI application."""
         async with self._transport.connect() as (read_stream, write_stream):
             server_task = asyncio.create_task(
-                read_only_server.run(
+                server.run(
                     read_stream,
                     write_stream,
-                    read_only_server.create_initialization_options(),
+                    server.create_initialization_options(),
                     stateless=True,
                 )
             )

--- a/src/omnifocus/mcp_server.py
+++ b/src/omnifocus/mcp_server.py
@@ -94,23 +94,6 @@ from omnifocus.store import OFocusStore
 # ---------------------------------------------------------------------------
 
 server: Server = Server("omnifocus")
-read_only_server: Server = Server("omnifocus-read-only")
-
-_READ_ONLY_TOOL_NAMES = frozenset(
-    {
-        "list_tasks",
-        "search_tasks",
-        "get_task",
-        "get_project",
-        "list_projects",
-        "list_projects_for_review",
-        "list_folders",
-        "get_folder",
-        "get_folder_tree",
-        "list_tags",
-        "get_tag",
-    }
-)
 
 
 # ---------------------------------------------------------------------------
@@ -588,12 +571,6 @@ async def list_tools() -> list[Tool]:
 # ---------------------------------------------------------------------------
 
 
-@read_only_server.list_tools()  # type: ignore[no-untyped-call, untyped-decorator]
-async def list_read_only_tools() -> list[Tool]:
-    """List the server-enforced read-only MCP tool surface."""
-    return [tool for tool in await list_tools() if tool.name in _READ_ONLY_TOOL_NAMES]
-
-
 @server.call_tool()  # type: ignore[untyped-decorator]
 async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
     """Dispatch incoming tool calls to the appropriate handler."""
@@ -632,14 +609,6 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
         return await typed_handler(arguments)
     except OFError as exc:
         return _text({"error": str(exc)})
-
-
-@read_only_server.call_tool()  # type: ignore[untyped-decorator]
-async def call_read_only_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
-    """Dispatch only read-only tools for the network MCP transport."""
-    if name not in _READ_ONLY_TOOL_NAMES:
-        return _text({"error": f"Tool is not available from the read-only server: {name}"})
-    return cast(list[TextContent], await call_tool(name, arguments))
 
 
 async def _handle_list_tasks(args: dict[str, Any]) -> list[TextContent]:

--- a/tests/test_http_api.py
+++ b/tests/test_http_api.py
@@ -34,6 +34,7 @@ from omnifocus.http_api import (
     main,
     run_server,
 )
+from omnifocus.models import OFModel
 
 _TEST_API_KEY = "test-api-key"
 _TEST_ALLOWED_HOSTS = ("testserver", "127.0.0.1", "localhost")
@@ -347,7 +348,7 @@ def _create_client(
     )
 
 
-class TestReadOnlyMCP:
+class TestMCP:
     def test_default_app_has_no_mcp_lifespan(self) -> None:
         client = _create_client(_FakeService())
 
@@ -364,8 +365,9 @@ class TestReadOnlyMCP:
 
         assert response.status_code == 401
 
-    def test_initializes_and_lists_read_only_tools(self) -> None:
-        client = _create_client(_FakeService(), enable_mcp=True)
+    def test_initializes_lists_and_calls_mutation_tools(self) -> None:
+        service = _FakeService()
+        client = _create_client(service, enable_mcp=True)
         initialize = {
             "jsonrpc": "2.0",
             "id": 1,
@@ -377,17 +379,31 @@ class TestReadOnlyMCP:
             },
         }
         list_tools = {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}
+        add_task = {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {"name": "add_task", "arguments": {"name": "Plan release"}},
+        }
         headers = _auth_headers(Accept="application/json, text/event-stream")
 
-        with client:
-            initialized = client.post("/mcp/", json=initialize, headers=headers)
-            tools = client.post("/mcp/", json=list_tools, headers=headers)
+        with (
+            patch("omnifocus.mcp_server._service", return_value=service),
+            patch("omnifocus.mcp_server._load_model", new=AsyncMock(return_value=OFModel())),
+        ):
+            with client:
+                initialized = client.post("/mcp/", json=initialize, headers=headers)
+                tools = client.post("/mcp/", json=list_tools, headers=headers)
+                added = client.post("/mcp/", json=add_task, headers=headers)
 
         assert initialized.status_code == 200
         assert tools.status_code == 200
+        assert added.status_code == 200
         names = {tool["name"] for tool in tools.json()["result"]["tools"]}
         assert "list_tasks" in names
-        assert "add_task" not in names
+        assert "add_task" in names
+        assert service.calls[-1][0] == "add_task"
+        assert service.calls[-1][1]["name"] == "Plan release"
 
 
 def _write_self_signed_cert(tmp_path: Path) -> tuple[Path, Path]:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -51,9 +51,7 @@ from omnifocus.mcp_server import (
     _text,
     _validate_folder_parent_change,
     _validate_tag_parent_change,
-    call_read_only_tool,
     call_tool,
-    list_read_only_tools,
     list_tools,
     main,
 )
@@ -1694,31 +1692,6 @@ class TestText:
         assert result[0].type == "text"
         parsed = json.loads(result[0].text)
         assert parsed["key"] == "value"
-
-
-class TestReadOnlyServer:
-    @pytest.mark.asyncio
-    async def test_lists_only_read_tools(self) -> None:
-        tools = await list_read_only_tools()
-
-        assert tools
-        assert {tool.name for tool in tools}.isdisjoint(
-            {"add_task", "complete_task", "sync_now", "drop_folder"}
-        )
-
-    @pytest.mark.asyncio
-    async def test_rejects_mutation_tools(self) -> None:
-        result = await call_read_only_tool("add_task", {"name": "Nope"})
-
-        assert "not available from the read-only server" in result[0].text
-
-    @pytest.mark.asyncio
-    async def test_dispatches_read_tools(self) -> None:
-        expected = _text({"tasks": []})
-        with patch("omnifocus.mcp_server.call_tool", new=AsyncMock(return_value=expected)):
-            result = await call_read_only_tool("list_tasks", {})
-
-        assert result == expected
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- route the HTTPS MCP adapter through the same complete MCP server as stdio
- remove the temporary read-only HTTP MCP allowlist
- document full read/write Hermes access and release v1.4.0

## Validation
- mypy src/
- black --check src/ tests/
- ruff check src/ tests/
- pytest --cov=src/omnifocus --cov-report=term-missing --cov-fail-under=100 -q (940 passed, 100% coverage)