### PR TITLE
Fix HTTPS listener TLS context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-07-18
+
+### Fixed
+
+- Configure Uvicorn's TLS context before server startup so the HTTPS listener
+  presents its certificate and enforces TLS 1.3
+
 ## [1.4.0] - 2026-07-18
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnifocus-cli"
-version = "1.4.0"
+version = "1.4.1"
 description = "Independent CLI and MCP server for OmniFocus 4, running in Podman"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/omnifocus/http_api.py
+++ b/src/omnifocus/http_api.py
@@ -1572,9 +1572,9 @@ async def _serve_uvicorn(
         log_level="warning",
         server_header=False,
         date_header=False,
+        ssl_context_factory=lambda _uvicorn_config, _default_factory: build_ssl_context(config),
     )
     uvicorn_config.load()
-    uvicorn_config.ssl = build_ssl_context(config)
     server = uvicorn.Server(uvicorn_config)
     await server.serve()
 

--- a/tests/test_http_api.py
+++ b/tests/test_http_api.py
@@ -1218,8 +1218,9 @@ class TestHTTPServerRuntime:
         config_kwargs = mock_config.call_args.kwargs
         assert config_kwargs["server_header"] is False
         assert config_kwargs["date_header"] is False
-        assert isinstance(fake_uvicorn_config.ssl, ssl.SSLContext)
-        assert fake_uvicorn_config.ssl.minimum_version == ssl.TLSVersion.TLSv1_3
+        ssl_context = config_kwargs["ssl_context_factory"](MagicMock(), MagicMock())
+        assert isinstance(ssl_context, ssl.SSLContext)
+        assert ssl_context.minimum_version == ssl.TLSVersion.TLSv1_3
         mock_server.assert_called_once_with(fake_uvicorn_config)
         fake_server.serve.assert_awaited_once_with()
 


### PR DESCRIPTION
Fixes the v1.4.0 runtime TLS startup defect by using the Uvicorn SSL context factory during Config.load(). Validation: mypy, Black, Ruff, 940 tests, 100% coverage.